### PR TITLE
Add aria-hidden=true and focusable=false to logo-svg

### DIFF
--- a/src/includes/header.njk
+++ b/src/includes/header.njk
@@ -1,6 +1,6 @@
 <header class="header">
     <a href="/" class="logo iconlink">
-        <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+        <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
             <path d="M19.64 16.36L11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z"/>
         </svg>
         {{ meta.title }}


### PR DESCRIPTION
If not set, in some browsers this logo-svg will be announced as "unnown" when voice over is enabled.